### PR TITLE
Update docs for new configuration features

### DIFF
--- a/mongo/content.md
+++ b/mongo/content.md
@@ -10,70 +10,126 @@ First developed by the software company 10gen (now MongoDB Inc.) in October 2007
 
 # How to use this image
 
-## start a mongo instance
+## Start a `%%IMAGE%%` server instance
 
 ```console
-$ docker run --name some-mongo -d %%IMAGE%%
+$ docker run --name some-%%REPO%% -d %%IMAGE%%:tag
+```
+... where `some-%%REPO%%` is the name you want to assign to your container and tag is the tag specifying the Mongo version you want. See the list above for relevant tags.
+
+## Connect to Mongo from an application in another Docker container
+
+This image includes `EXPOSE 27017` (the standard Mongo port), so standard container linking will make it automatically available to the linked containers (as the following examples illustrate).
+
+```console
+$ docker run --name some-app --link some-%%REPO%%:mongo -d application-that-uses-mongo
 ```
 
-This image includes `EXPOSE 27017` (the mongo port), so standard container linking will make it automatically available to the linked containers (as the following examples illustrate).
+## Connect to Mongo from the Mongo command line client
 
-## connect to it from an application
+The following command starts another `%%IMAGE%%` container instance and runs the `mongo` command line client against your original `%%IMAGE%%` container, allowing you to execute Mongo statements against your database instance:
 
 ```console
-$ docker run --name some-app --link some-mongo:mongo -d application-that-uses-mongo
+$ docker run -it --link some-%%REPO%%:mongo --rm %%IMAGE%% sh -c 'exec mongo "$MONGO_PORT_27017_TCP_ADDR:$MONGO_PORT_27017_TCP_PORT/test"'
+```
+... where `some-mongo` is the name of your original `mongo` container.
+
+## ... via `docker-compose`
+
+Example `docker-compose.yml` for `mongo`:
+
+```
+version: '2.1'
+
+services:
+
+  db:
+    image: %%IMAGE%%
+    restart: always
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: MongoRootUser
+      MONGO_INITDB_ROOT_PASSWORD: AMuchStrongerPassword
+      
+  app:
+    build: ./app
+    ports:
+      - 80:80
+    links:
+      - db
 ```
 
-## ... or via `mongo`
+## Container shell access and viewing Mongo logs
+
+The `docker exec` command allows you to run commands inside a Docker container. The following command line will give you a bash shell inside your `%%IMAGE%%` container:
 
 ```console
-$ docker run -it --link some-mongo:mongo --rm %%IMAGE%% sh -c 'exec mongo "$MONGO_PORT_27017_TCP_ADDR:$MONGO_PORT_27017_TCP_PORT/test"'
+$ docker exec -it some-%%REPO%% bash
+```
+
+The Mongo Server log is available through Docker's container log:
+
+```console
+$ docker logs some-%%REPO%%
 ```
 
 ## Configuration
 
 See the [official docs](https://docs.mongodb.com/manual/) for infomation on using and configuring MongoDB for things like replica sets and sharding.
 
+## Using a custom Mongo configuration file
+
+The `--config` option can be used to customize Mongo startup configuration. If you want to use a customized Mongo configuration, you can create your alternative configuration file in a directory on the host machine and then mount that directory location inside the `%%IMAGE%%` container. Note that a few problematic kets are removed from a provided `--config` file: `systemLog`, `processManagement`, `net`, and `security`.
+
+If `/my/custom/config-file.conf` is the path and name of your custom configuration file, you can start your `%%IMAGE%%` container like this (note that only the directory path of the custom config file is used in this command):
+
+```console
+$ docker run --name some-%%REPO%% -v /my/custom:/etc/mongo/conf.d -d %%IMAGE%%:tag mongo --config /etc/mongo/conf.d/config-file.conf
+```
+
+## Customize storage engine without configuration file
+
 Just add the `--storageEngine` argument if you want to use the WiredTiger storage engine in MongoDB 3.0 and above without making a config file. WiredTiger is the default storage engine in MongoDB 3.2 and above. Be sure to check the [docs](https://docs.mongodb.com/manual/release-notes/3.0-upgrade/#change-storage-engine-for-standalone-to-wiredtiger) on how to upgrade from older versions.
 
 ```console
-$ docker run --name some-mongo -d %%IMAGE%% --storageEngine wiredTiger
+$ docker run --name some-%%REPO%% -d %%IMAGE%% --storageEngine wiredTiger
 ```
 
-### Authentication and Authorization
+## Environment Variables
 
-MongoDB does not require authentication by default, but it can be configured to do so. For more details about the functionality described here, please see the sections in the official documentation which describe [authentication](https://docs.mongodb.com/manual/core/authentication/) and [authorization](https://docs.mongodb.com/manual/core/authorization/) in more detail.
+When you start the `%%IMAGE%%` image, you can adjust the configuration of the Mongo instance by passing one or more environment variables on the `docker run` command line.
 
-#### Start the Database
+### `MONGO_INITDB_ROOT_USERNAME`, `MONGO_INITDB_ROOT_PASSWORD`
 
+These variables are optional, used in conjunction to create a new user and to set that user's password. This user will be created in the `admin` authentication database and given the role of `root`. superuser permissions (see above) for the database specified by the `MYSQL_DATABASE` variable. Both variables are required for a user to be created. If both are present then Mongo will start with authentication enabled: `mongod --auth`. Authentication in MongoDB is fairly complex, so more complex user setup is explicitly left to the user via `/docker-entrypoint-initdb.d/` (see _Initializing a fresh instance_ below).
+
+Do note that MongoDB does not require authentication by default, but it can be configured to do so. For more details about the functionality described here, please see the sections in the official documentation which describe [authentication](https://docs.mongodb.com/manual/core/authentication/) and [authorization](https://docs.mongodb.com/manual/core/authorization/) in more detail.
+
+If you do create a root user, you will need to connect against the `admin` authentication database:
 ```console
-$ docker run --name some-mongo -d mongo --auth
-```
-
-#### Add the Initial Admin User
-
-```console
-$ docker exec -it some-mongo mongo admin
-connecting to: admin
-> db.createUser({ user: 'jsmith', pwd: 'some-initial-password', roles: [ { role: "userAdminAnyDatabase", db: "admin" } ] });
-Successfully added user: {
-	"user" : "jsmith",
-	"roles" : [
-		{
-			"role" : "userAdminAnyDatabase",
-			"db" : "admin"
-		}
-	]
-}
-```
-
-#### Connect Externally
-
-```console
-$ docker run -it --rm --link some-mongo:mongo %%IMAGE%% mongo -u jsmith -p some-initial-password --authenticationDatabase admin some-mongo/some-db
+$ docker run -it --rm --link some-%%REPO%%:mongo %%IMAGE%% mongo -u jsmith -p some-initial-password --authenticationDatabase admin some-%%REPO%%/some-db
 > db.getName();
 some-db
 ```
+
+### `MONGO_INITDB_DATABASE`
+
+This variable is optional and allows you to specify the name of a database to be used for creation scripts in `/docker-entrypoint-initdb.d/*.js` (see _Initializing a fresh instance_ below). MongoDB is fundamentally designed for "create on first use" so automating database creation does not make much sense.
+
+## Docker Secrets
+
+As an alternative to passing sensitive information via environment variables, `_FILE` may be appended to the previously listed environment variables, causing the initialization script to load the values for those variables from files present in the container. In particular, this can be used to load passwords from Docker secrets stored in `/run/secrets/<secret_name>` files. For example:
+
+```console
+$ docker run --name some-%%REPO%% -e MONGO_INITDB_ROOT_PASSWORD_FILE=/run/secrets/mongo-root -d %%IMAGE%%:tag
+```
+
+Currently, this is only supported for `MONGO_INITDB_ROOT_USERNAME` and `MONGO_INITDB_ROOT_PASSWORD`.
+
+# Initializing a fresh instance
+
+When a container is started for the first time it will execute files with extensions `.sh` and `.js` that are found in `/docker-entrypoint-initdb.d`. Files will be executed in alphabetical order. `.js` files will be executed by Mongo using the database specified by the `MONGO_INITDB_DATABASE` variable, if it is present, or `test` otherwise. You may also switch databases within the `.js` script.
+
+# Caveats
 
 ## Where to Store Data
 
@@ -101,4 +157,12 @@ Note that users on host systems with SELinux enabled may see issues with this. T
 
 ```console
 $ chcon -Rt svirt_sandbox_file_t /my/own/datadir
+```
+
+## Creating database dumps
+
+Most of the normal tools will work, although their usage might be a little convoluted in some cases to ensure they have access to the `mongod` server. A simple way to ensure this is to use `docker exec` and run the tool from the same container, similar to the following:
+
+```console
+$ docker exec some-%%REPO%% sh -c 'exec mongodump -d <database_name> --archive' > /some/path/on/your/host/all-collections.archive
 ```


### PR DESCRIPTION
This is mostly based on the MySQL docs. Some notes:

- I did not use %%STACK%% with a `stack.yml` because the [`adminer`](https://hub.docker.com/_/adminer/) image does not work with MongoDB and I could not quickly find and vet another Mongo admin image.
- I wasn't sure whether this image has the same [problems](https://github.com/docker-library/docs/blob/master/mysql/content.md#environment-variables) around environment variables as MySQL so I skipped mentioning them.
- Example location of mongo config file may not make sense or reflect best practices.

@yosifkit, @tianon
